### PR TITLE
recursive script

### DIFF
--- a/news/xxxx.bugfix.md
+++ b/news/xxxx.bugfix.md
@@ -1,0 +1,1 @@
+Refuse to run recursive composite scripts.


### PR DESCRIPTION
- **chore: Replace deprecated `set-output` command with `GITHUB_OUTPUT` file (#1434)**
- **chore: fix typo in documentation link id (#1436)**
- **fix: Correctly overrive the command**
- **fix: Ignore the unknown fields when constructing a requirement object Fix #1445**
- **doc: update the contributing guide**
- **doc: fix a broken link in CONTRIBUTING.md (#1449)**
- **feat: customizable theme colors (#1452)**
- **feat: write useful informations for github action (#1453)**
- **feat: set field as dynamic if variable exists in req**
- **feat: add `--check` flag to `pdm lock` (#1460)**
- **fix: update the completion script for the new --check flag**
- **feat: option to ship pip when creating a venv (#1463)**
- **fix: use pypi importlib_metadata on python < 3.10 (#1467)**
- **fix: Fix a bug of unrelated candidates being fetched Close #1465**
- **correct default value for resolve_max_rounds in documentation (#1472)**
- **feat: enhance the pdm list command (#1469)**
- **feat: pdm lock --check pre-commit hook (#1475)**
- **fix: don't override default handling of SIGINT**
- **chore: add release note for #1469**
- **feat: show warning if attempting to add this project as dependency Fix #1466**
- **chore: Release 2.2.0**
- **fix: Make `sitecustomize.py` respect the `PDM_PROJECT_MAX_DEPTH` environment variable. Resolves #1413. (#1480)**
- **fix: python_version comparison in environment markers (#1486)**
- **[pre-commit.ci] pre-commit autoupdate (#1485)**
- **fix: no need to write setup.py anymore**
- **chore: Release 2.2.1**
- **fix: Do not add local package to lockfile (#1481)**
- **chore: change the python version to download (#1490)**
- **fix: bump the lockfile version to 4.1**
- **fix: accept local versions as compatible packages related to #1497**
- **refactor: project files (#1499)**
- **feat: beautify the build error (#1501)**
- **feat: rename the resolution.overrides table (#1503)**
- **feat: remove backend specific code to support multiple backends (#1506)**
- **chore: remove benchmark code and page**
- **fix: Handle "sh" and "dash" in print_pep582_command (#1502) (#1511)**
- **fix: fix the confusing message when detecting python Fix #1508**
- **doc: reflect the changes**
- **doc: mention the requirement to import from setup.py**
- **doc: fix venv.with_pip syntax error (#1512)**
- **fix: fix the module loading of pth files for install cache Fix #863**
- **fix: test against the latest findpython (#1518)**
- **fix: fix the url mismatch in resolution when it contains variables Resolve #1513**
- **fix: improve the error report for resolution (#1519)**
- **fix: don't check content of files other than pyproject.toml for poetry format related: #1522**
- **Fix finding interpreters if file matches spec (#1524)**
- **fix: make the pdm sessions identical**
- **fix: test failures and upgrade unearth**
- **feat: replace pep517 with pyproject-hooks (#1528)**
- **docs: clarify the behavior of includes (#1532)**
- **feat(scripts): add an optional `{args[:defaults]}` placeholder for script arguments (#1533)**
- **feat: add pdm-backend to the supported backends**
- **chore: update doc dependencies**
- **chore: Release 2.3.0**
- **chore: add trackgit badge**
- **use flake8 'extend-exclude' instead of 'exclude' (#1540)**
- **fix: Fix minimum version requirement for tomlkit (#1539)**
- **fix: don't give duplicate results when specifying a relative path for pdm use Fix #1542**
- **fix: Fix a resolution loop issue when the current project depends on itself Fix #1541**
- **chore: update the lower bound for findpython**
- **chore: Release 2.3.1**
- **[pre-commit.ci] pre-commit autoupdate (#1545)**
- **fix: fallback to pdm.pep517 for unknown custom build backend (#1546)**
- **feat: make it possible to override the task runner**
- **fix: ctrl + c on latest PDM exits python interactive session instead of clearing the current line Close #1547**
- **feat: update installer to 0.6.0 (#1550)**
- **chore: update deps unearth and packaging (#1555)**
- **fix: egg segment for local dependency (#1552)**
- **chore: Release 2.3.2**
- ** fix: support relative paths in build requires (#1561)**
- **fix: reread the version after update Close #1563**
- **fix: Strip the local part when building a specifier for comparison (#1566)**
- **fix: Exclude `packaging 22.0` to avoid breakage (#1568)**
- **feat: remove usages of __file__ to support pdm in a zipapp (#1567)**
- **fix: matching problem of packages in lockfile (#1570)**
- **chore: Release 2.3.3**
- **fix: don't write sitecustomize.py when not packed in a zipapp Fix #1572**
- **fix: write the version statically in wheel**
- **feat: disable some functions when in zipapp Fix #1578**
- **fix: correctly mark a symlink as file to remove (#1581)**
- **fix: remove unused object**
- **chore: ignore coverage warnings (#1582)**
- **chore: Release 2.3.4**
- **Fix small wording issues (#1589)**
- **[pre-commit.ci] pre-commit autoupdate (#1593)**
- **fix: raise an error instead of warning for Python 2 Close #1590**
- **feat(pytest): expose pytest fixtures and helpers for pdm plugins (#1594)**
- **feat: support multiple indexes in config (#1597)**
- **fix: exclude site-packages for symlinks of the python executable**
- **fix: filter out invalid python paths Close #1601**
- **docs: add pdm expansions in header**
- **docs: don't show expansion if not initialized**
- **feat: show message in the status when fetching hashes Close #1609**
- **fix: logging for fetching hashes**
- **fix: fetch hashes from the JSON API response Related to #1609**
- **fix: fix an uninstallation error on Windows (#1605)**
- **fix: hide spinner output for build resolver**
- **feat(lockfile): add `@generated` comment (#1612)**
- **fix(run): fix the way of expanding command**
- **feat: Accept yanked versions when the requirement version is pinned Close #1575**
- **chore: Release 2.4.0**
- **docs: Fix typo in help output of update command (#1615)**
- **doc: fix configuration typo for `venv.in_project` (#1617)**
- **chore: correct some cli typos (#1618)**
- **fix: skip python requirements for overriden packages Fix #1575**
- **fix: fix linter error**
- **fix: Deduplicate lists when running pdm import (#1627)**
- **feat: support implicit python script execution (#1628)**
- **fix: missing subdirectory in lockfile Fix #1630**
- **fix: fix the wildcards in requirement specifiers (#1632)**
- **docs: fixed misplaced backtick (#1633)**
- **chore: fix some wording**
- **docs: update default value (#1636)**
- **doc(readme): remove the pep 582 part and add comparison Close #1637**
- **fix(build): Ensure the destination directory exists Fix #1647**
- **fix(ui): Redirect the spinner output to stderr FIx #1646**
- **fix: proper display for extra Pypi indexes config (#1622)**
- **fix(resolution): VCS locks don't update when the rev part changes Close #1640**
- **fix: correct the hash key for requirements (#1648)**
- **chore: Release 2.4.1**
- **doc: add umami analytics**
- **fix: Skip some tests on packaging < 22 Close #1649**
- **fix: load pypi sources from project config (#1651)**
- **fix: Set VIRTUAL_ENV in pdm run (#1652)**
- **chore: fix pre-commit hooks**
- **chore: Release 2.4.2**
- **fix: change the fallback build backend to `pdm-pep517` Close #1658**
- **fix: try a second source for the packaging version in case importlib metadata failed (#1656)**
- **- added a check to pack pdm and at least print the version... (#1665)**
- **fix: eliminate the importlib.resources warnings (#1661)**
- **fix: don't crash for check_udpate close #1663**
- **fix: allow force re-creating venv in project (#1666)**
- **fix: the priorities of importable formats Close #1669**
- **feat: ignore remembered selection in pdm init (#1673)**
- **fix: import editable requirements into dev dependencies (#1676)**
- **chore: Release 2.4.3**
- **[pre-commit.ci] pre-commit autoupdate (#1682)**
- **chore: update findpython to 0.2.4 (#1696)**
- **fix: prefer built distributions (#1697)**
- **feat(resolution): improve the error message when requires-python doesn't work Close #1690**
- **chore: Release 2.4.4**
- **fix: fix the incorrect priority for binary wheels Fix #1698**
- **chore: Release 2.4.5**
- **fix: Don't crash when trying to update the shebang in a binary script (#1710)**
- **fix: resolution failure with nested relative path deps (#1712)**
- **docs: Improve contributing docs (#1713)**
- **chore: lint with Ruff (#1715)**
- **fix: ignore the expressions in dependency list when parsing setup.py Fix #1720**
- **fix: Handle the legacy specifiers Close #1719**
- **fix wrong file name for pdm.lock (#1727)**
- **docs: install via asdf-vm (#1725)**
- **fix: fix a bug converting from flit metadata when the source file can't be found Fix #1726**
- **doc: Add pyright/eglot config for emacs (#1721)**
- **chore: Release 2.4.6**
- **chore: correct the checksum of install script, closing #1737**
- **fix: a local packages finding issue**
- **fix: Ensure UTF-8 encoding when generating README.md Close #1739**
- **fix: fix a bug of show command not showing metadata of current project (#1740)**
- **fix: Unable to export requirements.txt from unpinned dependencies Fix #1730**
- **fix: unexpected `--prompt` arg in `conda create` Close #1734**
- **fix: Replace `.` with `-` when normalizing package name Close #1745**
- **fix: in project conda venv activate without argument (#1735)**
- **chore: Release 2.4.7**
- **[pre-commit.ci] pre-commit autoupdate (#1755)**
- **Fix to ensure auth is returned correctly (#1759)**
- **Fix the resolution order to prefer the packages causing the conflict (#1760)**
- **chore: Release 2.4.8**
- **fix: `pdm update` do not intstall proper revision of git dependency Close #1762**
- **fix: improve the error message when encountering an invalid requirement (#1766)**
- **fix: Export from pyproject.toml doesn't include "extras" Close #1767**
- **doc: fix mismatching help text in configuration.md Close #1769**
- **chore: Release 2.4.9**
- **Update CHANGELOG.md (#1774)**
- **fix: no need to check `PYTHONPATH` before setting it in fish (#1780)**
- **feat(venv): add option to show the path to a venv (#1680)**
- **feat(core) merge index parameters (#1683)**
- **feat: switch the default build backend to pdm-backend (#1684)**
- **doc: improve and restructure the docs (#1687)**
- **doc: add redirects map for moved pages (#1688)**
- **fix: Fix the log leakage in installation (#1689)**
- **feat(install): fail-fast (#1691)**
- **feat: write groups to the metadata section of lockfile (#1692)**
- **fix: move the logging to where it actually happens**
- **chore: update the completion scripts**
- **feat: add option --lib to init command to create a library project (#1708)**
- **feat: encode selected groups into lockfile (#1741)**
- **feat: move the python.path to its own config file (#1742)**
- **feat: add pdm fix and hint when invoking pdm commands (#1743)**
- **feat: upgrade unearth to 0.8 to enable calling keyring from CLI (#1744)**
- **chore: update the description of python.use_venv**
- **refactor: clean the code of hooks**
- **feat: add autogen header to the generated requirements.txt**
- **feat: ignore active venv (#1782)**
- **dep: Update installer to 0.7.0 to enable RECORD validation (#1784)**
- **feat: write .pdm-python to .gitignore when running pdm init (#1785)**
- **fix: show the actual version when running pdm show --version Close #1788**
- **fix: non-deterministic order when running `pdm export` Fix #1786**
- **chore: update resolvelib to 1.0.1**
- **chore: update pyproject.toml**
- **refactor: Refactor environment package (#1791)**
- **feat: signal to emit before any command is invoked (#1792)**
- **Correct the news types**
- **chore: Release 2.5.0b0**
- **Fix powershell completion script (#1795)**
- **fix: do not validate against locked groups in lock command (#1797)**
- **fix: avoid duplicate .pdm-python in .gitignore. (#1802)**
- **doc: add env var instruction for check_update**
- **refactor: change the internal variable names to be more descriptive**
- **[pre-commit.ci] pre-commit autoupdate (#1810)**
- **fix: adding back the `environment.is_global` property for compatibility Fix #1814**
- **feat: lazily evaluate sources when respect-source-order is true (#1817)**
- **docs: add news for prefer_binary**
- **feat: New option `--venv VENV` to run a command in the venv with the given name (#1820)**
- **chore: suggest --pre flag when the latest version is a prerelease**
- **fix: Fix two bugs (#1822)**
- **fix the typo**
- **chore: Release 2.5.0**
- **fix: CLI parse error when running `pdm --pep582` Fix #1823**
- **chore: Release 2.5.1**
- **fix: rename the PDM_USE_VENV to PDM_IN_VENV for --venv flag Fix #1829**
- **fix: Regression: updating shebang in binary files Close #1827**
- **chore: improve clarity of prompt in the init command (#1825)**
- **chore: Release 2.5.2**
- **doc: add example for monorepo**
- **fix: show different command for global project**
- **fix: wrong argument validation for update command (#1836)**
- **doc(#1833): Fix hooks' composite usage**
- **doc(#1840): Remove advertizing of PEP-582 from Feature highlights (#1841)**
- **chore: Release 2.5.3**
- **chore: switch to trusted publisher for pypi release**
- **Update venv.md (#1850)**
- **fix: fixed zsh completions by replacing brackets in option descriptions (#1848)**
- **fix(#1851): The resolver doesn't take into account of the requirements from both bare package and package[extra] (#1852)**
- **feat(commands): added a `--json` option to `info` and `run` command (#1854)**
- **doc(cli): improve cli reference display (#1853)**
- **fix: Fix the flaky tests depending on httpbin**
- **feat(scripts): hide tasks starting with an underscore from listing (#1855)**
- **fix: Default pypi source gets password <hidden> (#1858)**
- **chore: update completion scripts**
- **doc: remove obsoleted links to close #1844**
- **doc: Document installing pip with ensurepip (#1860)**
- **feat: create venv when running pdm init -n (#1862)**
- **doc: add news**
- **[pre-commit.ci] pre-commit autoupdate (#1871)**
- **fix: More user-friendly error message for pdm add local package Close #1875**
- **Fix typo in docs/docs/usage/scripts.md (#1881)**
- **chore: separate pack job from CI**
- **fix: patch cachecontrol instead of pinning urllib3**
- **feat: add an ephemeral wheel cache in process (#1885)**
- **refactor: Extract the logic about virtualenv to its own module (#1889)**
- **feat: allow self-referencing groups in dev-dependencies (#1890)**
- **fix(#1894): PDM fails during package download when running pdm build**
- **fix: don't raise error if the selected group no longer exists**
- **feat: install plugins from project config (#1893)**
- **feat: PyPI Trusted Publisher Support (#1899)**
- **feat: option to create non-crossplatform lockfile (#1898)**
- **fix: the self package isn't uninstallable (#1903)**
- **chore: Release 2.6.0**
- **chore: update docs**
- **fix: the PATH env isn't set correctly under no-build-isolation (#1904)**
- **fix: error occurs when publishing using trusted publisher. Related #1868**
- **ci: use pdm to build and publish**
- **chore: Release 2.6.1**
- **refactor: reduce repeating code in config and clean the types (#1912)**
- **fix: Fix a number of `ResourceWarning`s when running the test suite (#1915)**
- **Lock file hash never matches with --dev (#1918)**
- **feat: Credential-related config options utilize keyring if it is installed (#1914)**
- **feat: Add support for reading metadata from PyPI directly (#1919)**
- **ci: use the currently build pdm for the following steps**
- **Document ability to install deps from a plain URL (#1924)**
- **chore: update locked version of unearth**
- **refactor: lazy import to reduce the startup time (#1929)**
- **fix: Ignore PYTHON* env var when installing pdm**
- **doc: fix XDG_CONFIG_HOME and XDG_CONFIG_DIRS on macOS, fix macOS capitalization. (#1931)**
- **refactor: move do_init/do_build into command**
- **fix: PDM stuck when running pdm init Close #1937**
- **doc: Update publish.md to use run instead of runs (#1936)**
- **fix: add pakcage without peotry config [tool.poetry.build] script would raise keyError (#1938)**
- **rename news fragmeent**
- **fix: don't use install cache when installing build requirements to avoid race condition (#1943)**
- **fix: pdm export support env variables in credentials Fixes #1939**
- **fix: replace cachecontrol with cacheyou**
- **feat: add local plugin scripts to PATH env (#1944)**
- **fix: convert to boolean when setting verify_ssl for custom indexes (#1949)**
- **fix: `pdm import` clobbers `build-system.requires` value in `pyproject.toml` (#1950)**
- **doc(advanced): use `pdm sync` instead of `pdm install --no-lock` (#1947)**
- **doc: list repository configs in config list Close #1926**
- **feat: Add repository config verify ssl (#1954)**
- **feat: An option to specify constant command arguments via pyproject.toml (#1959)**
- **feat: add --no-verify-ssl option to publish command**
- **chore: Release 2.7.0**
- **fix: PDM ignores PDM_PYPI_USERNAME and PDM_PYPI_PASSWORD when there are no defaults in config (#1962)**
- **fix: add python prefix to the self update command on Windows (#1972)**
- **feat: add support for SplitBodyCache (#1971)**
- **fix: Fix path while import poetry deps (#1968)**
- **docs: fix configuration details for macOS (#1965)**
- **fix: guess name from the VCS url when importing requirements (#1970) (#1976)**
- **fix: reading config from env vars correctly (#1977)**
- **chore: Release 2.7.1**
- **refactor: move cli actions to the command class (#1983)**
- **doc: update the effect of pdm install**
- **[pre-commit.ci] pre-commit autoupdate (#1980)**
- **fix: `pdm init` in non-interactive mode does not respect `--python` option (#1985)**
- **fix: no crash when reading the old cache (#1986)**
- **fix: do not use nested argument groups**
- **fix: Fix typo in plugins (#1991)**
- **Add notes about Python version and license classifiers (#1992)**
- **fix: parsing setup.py error if it outputs to stdout (#1998)**
- **feat: add option to expand vars when exporting (#1997)**
- **fix: exclude yanked versions when running install-pdm.py Fix #1996**
- **fix: install-pdm.py looking in wrong place for `yanked` flag (#2002)**
- **update checksum**
- **Fix sorting case sensitivity in list command (#1973) (#1974)**
- **chore: Release 2.7.2**
- **ci: set PYTHONDEVMODE=1 (#2004)**
- **fix: ExtrasWarning: Extras not found for jax: [cuda12_pip] (#2007)**
- **chore: Close IO objects (#2005)**
- **fix: merging failure when the settings contain AoT Close #2011**
- **fix: deprecation warning when passing parser to Command.__init__ (#2010)**
- **chore: Release 2.7.3**
- **fix compatibility**
- **chore: Release 2.7.4**
- **fix: Breaking change: module 'pdm.cli.actions' has no attribute 'do_use' (#2017)**
- **fix: disable hashes cache for local files (#2019)**
- **Duplicate libraries in `pdm self list` (#2020)**
- **fix: create `.sha256` file for verfication and serve on the docs (#2026)**
- **fix: use the dev location**
- **fix: Refactor deprecated `warn` method and use appropriate warnings class (#2012)**
- **chore: remove unused file**
- **feat: new --edit option to edit config file in editor (#2028)**
- **add news**
- **chore: Fix typo in pdm pytest fixture docstring (#2029)**
- **fix: Populate the `url` field when converting requirements from a Pipfile-style file requirement**
- **fix: Yanked version might cause a conflict (#2039)**
- **doc: fix the doc issue of Changelog and Contributing empty Fix #2040**
- **fix: Empty source tables causing errors when runing pdm (#2043)**
- **doc: Remove pypi.<name>.ca_certs configuration option from docs (#2044)**
- **feat: add `--project` option to `pdm venv` (#2048)**
- **fix: Include default group when starting from an empty lockfile Fix #2050**
- **fix: PDM corrupts binary executable (ruff) (#2054)**
- **feat: Add support for truststore package (#2055)**
- **fix: update fish and bash completions**
- **fix: do not normalize name when uploading (#2057)**
- **feat: pdm init template argument (#2053)**
- **chore: Release 2.8.0a0**
- **chore: update changelog**
- **feat: support copier and cookiecutter as project generator (#2059)**
- **chore: Release 2.8.0a1**
- **fix: lock hooks emitted with dry_run=True when doing update (#2060)**
- **fix: correctly update dependencies for out-of-order table (#2061)**
- **chore: change the warning stacklevel**
- **fix: install --plugins cannot install self package (#2062)**
- **feat: support checking out branch or tag for git template**
- **fix: The cache collision issue between named requirements and url requirements (#2067)**
- **docs: fix Nox install command (#2069)**
- **chore: Release 2.8.0a2**
- **fix: completely remove egg-info when uninstalling Fix #2027**
- **fix: filter wrong package meta information and duplicate path (#2076)**
- **docs: Add instructions to copy executables in example Dockerfile (#2079)**
- **[pre-commit.ci] pre-commit autoupdate (#2077)**
- **feat: Support environment for other architecture (#2080)**
- **feat: display the help information when running pdm directly (#2082)**
- **fix: avoid mistakenly passing command-line arguments while testing (#2084)**
- **fix: don't overwrite lockfile when locking in `pdm install` (#2090)**
- **chore(ruff): use isort and extend-select (#2095)**
- **doc: Allow setting custom venv path Close #2096**
- **feat: new findpython (#2099)**
- **fix: also finds python3**
- **feat: option to save static URLs in the lockfile (#2101)**
- **fix: tolerate local version in specifiers (#2102)**
- **doc: update changelog**
- **doc: improve help info format for subcommands (#2103)**
- **fix: Shared cache cannot support overlapping directory structures (#2106)**
- **fix: minor efficiency improvement**
- **chore: Release 2.8.0**
- **chore: update lockfile**
- **feat: add optional keyring dependency target in pyproject.toml (#2109)**
- **chore: update lockfile**
- **fix: set upper bound for findpython**
- **feat: ignore wheels for pythons not in range (#2113)**
- **fix: Fix a build error due to old version of pdm-backeend Fix #2107**
- **fix: correct the comparison of candidate keys (#2123)**
- **fix: don't update pyproject.toml if dry-run mode is on Fix #2125**
- **fix: overwrite the build-system table**
- **doc: Corrected documented default value for `venv.in_project` (#2127)**
- **feat: read default value from env var**
- **fix: ignore empty source when merging sources (#2131)**
- **fix: invalid requirement converted from poetry metadata (#2135)**
- **chore: Release 2.8.1**
- **fix: use utf-8 encoding for writing Close #2139**
- **feat: Allow specifying username and password in URL (#2141)**
- **fix: respect the correct requirement Fix #2146**
- **chore: Release 2.8.2**
- **chore: Pre commit ci update config (#2157)**
- **core: move install-pdm.py to the root directory**
- **fix: Removing dev dependency uninstall the project as well (#2162)**
- **feat: support filter by patterns for pdm list command (#2165)**
- **doc: update doc dependencies**
- **feat: add an --overwrite option to pdm init (#2166)**
- **feat: remove legacy pdm-pep517 backend (#2167)**
- **doc: update umami track point**
- **fix: pdm does not update a `@ file:///` dependency (#2173)**
- **fix: Link is not defined if not TYPE_CHECKING but it's used Fixes #2151**
- **fix: crash issue when dependencies are requested out of python range (#2176)**
- **fix: command line args interpolation**
- **fix: compatibility issue with copier 8.0+ (#2178)**
- **fix: Fix comparable_version() (#2182)**
- **fix: shell detection failure (#2188)**
- **fix: change cache file path's type to Path | str (#2192)**
- **fix: remove duplicates in conflict report**
- **fix: Switch to Truststore by default (#2200)**
- **fix: merge directory based on the types of source Fix #2198**
- **doc: Update comparison with hatch in README (#2210)**
- **fix: Handle parsing errors when converting from poetry-style metadata (#2215)**
- **fix: Don't copy .pyc files from the template directory Close #2213**
- **doc: Correct a typo in project.md (#2212)**
- **feat: Allow using `pdm run` to run a command not on PATH (#2218)**
- **feat: Consider packages installed if the venv includes them from the system-site (#2219)**
- **chore: Release 2.9.0**
- **fix: `pdm run` conflicts between local file and PATH (#2223)**
- **feat: support converting setup.cfg without existing setup.py (#2224)**
- **chore: Release 2.9.1**
- **fix: pass user given spec to findpython Close #2225**
- **fix: use UTF-8 to read pyvenv.cfg Fix #2227**
- **doc: advanced.md: remove "isolated_build" tox option (#2231)**
- **fix: Accommodate virtual envs on Windows that use Unix path hierarchy. (#2236)**
- **doc: correct two typos (#2241)**
- **[pre-commit.ci] pre-commit autoupdate (#2233)**
- **fix: lock relocatable dependency URLs in the lockfile (#2242)**
- **docs: Fix configuration table entry for `pypi.<name>.type` (#2246)**
- **add tox.ini in sdist (#2248)**
- **fix: --no-lock doesn't work (#2250)**
- **chore: Release 2.9.2**
- **Create SECURITY.md**
- **doc: add doc for achieving `pdm shell` Close #2249**
- **ci: Enable CI on Python 3.12 (#2257)**
- **doc: clarify --no-isolation option (#2229)**
- **fix: PDM crashes in case of invalid package metadata (#2263)**
- **fix: revert the change of install self (#2264)**
- **docs: update github actions version (#2265)**
- **chore: update dependencies**
- **doc: add note about installing into global python (#2271)**
- **chore: Release 2.9.3**
- **fix incorrect/inconsistent "available in project" values (#2278)**
- **doc: mention that all `pdm` commands need to be run with the `pw` wrapper when installing with the "inside project" method (#2275)**
- **doc: improve error message**
- **refactor: Recursively look for the project root (#2286)**
- **fix: empty venv instead of remove it (#2282)**
- **doc: [project] not [projects] for mono repo usage docs (#2290)**
- **[pre-commit.ci] pre-commit autoupdate (#2294)**
- **chore: porting to python3.12 (#2301)**
- **fix: Cookiecutter raising exception instead of returning errcode (#2291)**
- **feat: --quiet optiona and package warning (#2304)**
- **Typo in docs/dependency.md (#2305)**
- **fix: print output only when writing lockfile**
- **fix: Dependency Groups from Poetry do not migrate properly to PDM (#2311)**
- **improve spelling (#2313)**
- **fix: Install build requirements into wrong location when running with --venv (#2314)**
- **doc: Separate private pypi password with @ instead of slash (#2315)**
- **docs: fix `pdm use` example for in-project venv (#2316)**
- **ci: utils test coverage improvements (#2283)**
- **Merge pull request from GHSA-j44v-mmf2-xvm9**
- **chore: update dependencies**
- **doc: Fix `venv.md` markup (#2318)**
- **feat: per-package source configuration (#2323)**
- **feat: shoot a warning when python 3.7 is detected**
- **feat: Add lock option to resolve direct dependencies to the minimal versions available (#2327)**
- **chore: update issue templates**
- **feat: report progress when downloading packages (#2328)**
- **doc: add a note about miminal version**
- **doc: Minor UI fixes for the new lock strategy arguments (#2329)**
- **fix: Global repository setting results in TypeError (#2331)**
- **fix: Credentials error when working with 2 indices on the same host (#2334)**
- **chore: Release 2.10.0**
- **fix: check list for empty build error output (#2346)**
- **fix: Export find-links correctly (#2343)**
- **doc: clarify the effect of `pdm venv activate` (#2350)**
- **doc: fix the invalid dynamic versioning link (#2352)**
- **fix: Subprocess signal forwarding on Windows (#2351)**
- **feat: use ruff-format replace black (#2356)**
- **fix: Installation failed when install.cache = true (#2359)**
- **Chat-bot (#2363)**
- **feat: add a chatbot in the doc page (#2365)**
- **doc: embed the chatbot**
- **fix: Incorrect resolution for JAX (#2371)**
- **doc: move doc domain to pdm-project.org**
- **doc: move backend doc domain to backend.pdm-project.org**
- **[pre-commit.ci] pre-commit autoupdate (#2374)**
- **chore: Release 2.10.1**
- **fix: Don't copy file permissions for templates (#2379)**
- **fix: PDM does not detect namespace packages correctly (#2381)**
- **fix: only resolve locked groups when running update**
- **chore(deps): bump pyarrow from 14.0.0 to 14.0.1 in /chatbot (#2391)**
- **fix: Don't reset the build backend when asking for import (#2393)**
- **chore: change the location of command logging**
- **fix: fix tests due to wrong mock target**
- **doc: use custom domain for expansions**
- **fix: improve the error message to tell user how to fix it (#2396)**
- **doc: update the venv docs to reflect the actual behavior**
- **fix: Never wrap the output of the `export` command (#2397)**
- **fix: validate the project name when running pdm init (#2402)**
- **fix: forbid global project in conda base env (#2410)**
- **feat: Provide response body upon HTTP fault with publish (#2400)**
- **chore: Release 2.10.2**
- **fix: Create virtualenv for conda base Python**
- **chore: Release 2.10.3**
- **fix: detection of conda python**
- **fix(#2417): provide context when parsing requirement fails**
- **fix: Do not detect as requirements.txt if the file is a python script**
- **fix: resolve requirements paths relative to the requirement file they are specified in (#2422)**
- **fix: inplace update (#2427)**
- **chore: Release 2.10.4**
- **doc: python version in doc (#2428)**
- **fix: `pdm init [-n]` ignores  `--backend` option (#2440)**
- **fix(#2436): `pdm init -n` does not respect global python with asdf/rtx/pyenv Fix #2436**
- **fix: Link collection ignores package-index-binding (#2444)**
- **chore: improve the logging when calling pip command**
- **docs: Clarify effect of requires-python on resolution (#2452)**
- **fix: indexerror when the causes are empty**
- **feat: Update PDM requirements to Python 3.8**
- **feat: improve the compatibility checking for lockfile (#2380)**
- **feat: use `==major.minor.*` as the default requires-python for applications (#2382)**
- **feat: Publish: add argument `--skip-existing` to avoid overwrite (#2383)**
- **feat: Change the style of logging status to console (#2384)**
- **feat: add a new setting `package-type` to distinguish application and library (#2394)**
- **chore: change to error**
- **fix: add support for `{pdm}` placeholder in scripts (#2408)**
- **feat: export cross-platform requirements (#2418)**
- **feat: add `--update-reuse` to lock command (#2419)**
- **feat: New lock strategy: inherit_metadata (#2421)**
- **feat: allow to include self when exporting to requirements (#2424)**
- **feat: new cache methods: hardlink and symlink_individual (#2425)**
- **doc: fix default verbosity level in UI.echo docstring (#2460)**
- **[pre-commit.ci] pre-commit autoupdate (#2462)**
- **fix: PDM installs wrong architecture of pywin32 wheel on Windows (#2467)**
- **feat: inherit metadata by default (#2468)**
- **feat: `pdm list` default sort by name**
- **doc: use py instead of python on Windows Fix #2469**
- **fix: Fix installing PEP 561 stub-only packages (#2466)**
- **feat: Add "pdm-sync" pre-commit hook (#2475)**
- **Update docs to remove export to `setup.py` information since that is not supported. (#2481)**
- **feat: New update strategy: reuse-installed (#2479)**
- **feat: Show subcommand's help info when passing unrecognized arguments (#2480)**
- **fix: `pdm update --dry-run --unconstrained` raises KeyError (#2484)**
- **doc: add news**
- **feat: add a `PDM_CACHE_DIR` environment variable (#2485)**
- **chore: Release 2.11.0**
- **chore: add changelog**
- **fix: update candidate key before resolving markers Fix #2488**
- **fix: KeyError when resolving packages that have parents that are no longer needed**
- **chore: Release 2.11.1**
- **docs: Fix typo in usage example (#2493)**
- **fix: pdm update --update-eager can hit InconsistentCandidate error when dependency is included both through default dependencies and extraFixes #2495Signed-off-by: Frost Ming <me@frostming.com>**
- **feat: added documentation for enabling 'pdm shell' for fish shell (#2500)**
- **fix(installers): don't warn when overwriting its own symlink on `install` with cache enabled (fixes #2502) (#2503)**
- **fix: zsh completion**
- **fix(#2507): PDM rejects candidates without local version when the local version is pinned. Close #2507**
- **chore: Change the template name to "Feature / Enhancement Request" (#2508)**
- **doc: Describe keyring support for pdm-sync pre-commit hook (#2516)**
- **fix: KeyError resolving URL dependency without name Resolve #2488**
- **docs: add maturin section (#2526)**
- **doc: Update references to Python 3.7 in docs (#2524)**
- **[pre-commit.ci] pre-commit autoupdate (#2528)**
- **chore(lib): enhance warning message (#2523)**
- **chore: Release 2.11.2**
- **doc: Remove mentions of npm in index**
- **fix: remove redundant code**
- **chore: fix target version to python38 Supersede #2494**
- **doc: improve the wording for choosing if a project is installable Close #2506**
- **fix: pdm list output containing full license text in some cases (#2539)**
- **fix: handle the case when a package is missing from lockfile**
- **fix: Environment variable substitution in `cmd` scripts**
- **doc: about environment substitution**
- **feat: Rename `--no-lock` option to `--frozen-lockfile`**
- **feat: add --no-markers to `export` command**
- **feat: remove some deprecated members**
- **dep(chatbot): update dependencies of chatbot**
- **fix: allow normal extension modules when the python is debug buildFixes #2548Signed-off-by: Frost Ming <me@frostming.com>**
- **feat: Allow exclusion of dependencies (#2551)**
- **feat: allow prereleases if a prerelease version is pinned for a specific package**
- **feat: Allow generating pyproject.toml without the extra project boilerplateResolve #2543Signed-off-by: Frost Ming <me@frostming.com>**
- **update pyprojectx install command (#2559)**
- **fix: don't use pypi.org when pypi.url is set (#2563)**
- **feat: don't build if the package type is not library**
- **feat: rename the package-type config to distribution**
- **chore: Release 2.12.0**
- **fix(fixer): hotfix: missing identifier**
- **chore: Release 2.12.1**
- **fix: updates instructions for private repositories in pdm publish. (#2569)**
- **fix: install headers into package namespace**
- **doc: add news**
- **doc: update doc with the correct executable installation destination Close #2565**
- **fix: Dependency with additional headers fails to installFixes #2573Signed-off-by: Frost Ming <me@frostming.com>**
- **fix: autofixer writes string "false/true" incorrectly**
- **chore: Release 2.12.2**
- **fix: `package-type fixer` to avoid duplicated empty section (#2578)**
- **perf: Warnings that the correct version cannot be matched before the environment is finally created. (#2584)**
- **fix: unable to force install specific version with pdmFixes #2586Signed-off-by: Frost Ming <me@frostming.com>**
- **doc: Fix typo in template docs (#2589)**
- **chore(deps): bump aiohttp from 3.9.1 to 3.9.2 in /chatbot (#2595)**
- **chore: add pyright venv path**
- **doc: Add missing "not" in docs/usage/config.md... (#2601)**
- **fix: Handle legacy specifiers when converting from poetry project. Fix #2599**
- **fix: Failed to clone template repository if the URL contains the rev part Close #2597**
- **chore: Release 2.12.3**
- **fix: reset project.environment when importing from setup.pyFixes #2608Signed-off-by: Frost Ming <me@frostming.com>**
- **doc: add missing cache method pth**
- **feature: Use env `PDM_NO_EDITABLE` as the default value for `--no-editable` option. (#2613)**
- **[pre-commit.ci] pre-commit autoupdate**
- **fix: pdm venv create succeeds/fails alternatelyFixes #2631Signed-off-by: Frost Ming <me@frostming.com>**
- **feat: Do not fetch package hashes when `--frozen-lockfile` is passed Close #2630**
- **doc: auto-gen config reference doc Close #2645**
- **refactor: dep-logic for python specifier logic**
- **fix: Don't cause a hard failure if the local directory doesn't exist Close #2650**
- **fix: Default values for CLI arguments not aligned with documentation. Fixes #2642**
- **doc: rename the news fragment**
- **chore: Release 2.12.4**
- **feat: Option to exclude optional groups from install/sync -G:all  (#2655)**
- **chore: Update constraint of unearth for timeout (#2659)**
- **feat: cache the decompressed content of wheels (#2660)**
- **doc: version added admonition**
- **doc: fix**
- **fix: pdm deletes ``pyproject.toml`` keys it's not authorized to. Fixes #2666**
- **docs: add admonition about tool.pdm.scripts vs project.scripts (#2673)**
- **fix(chatbot): update to the latest llama-index**
- **fix: group exclusion (#2670)**
- **feat: timeout config for network requests (#2683)**
- **fix: don't show empty config sections**
- **fix: Give a default version when it's missing in `pyproject.toml` when parsing candidate's metadata.**
- **fix: disable colors in pdm help on legacy terminals of windows (#2684)**
- **feat: Allow configuring log file directory (#2687)**
- **feat: An option to continue on errors for composite script (#2582)**
- **feat: config setting option for other commands that may build packages (#2688)**
- **chore: format using latest ruff**
- **fix: Expand user path for venv.location and possibly other config keys. (#2691)**
- **chore: fix the name of news**
- **fix: Add an option for PDM's scripts to set the current working directory (#2694)**
- **feat: reuse request sesison within the environment (#2697)**
- **feat: allow disabling caches with `--no-cache` option or `PDM_NO_CACHE` (#2702)**
- **refactor: switch to httpx client (#2709)**
- **removal: remove deprecated pdm.models.environment (#2710)**
- **feat: Ability to take into account a limit date to compute a lockfile (#2712)**
- **fix: improve the help message of pdm lock --refresh**
- **chore: delete `setup.cfg`, move tool configurations under it to `pyproject.toml` (#2711)**
- **feat: allow updating specific sub-deps with `--allow-transitive` flag (#2689) (#2714)**
- **feat: New command `pdm outdated` (#2718)**
- **feat: create venv when switching python versions (#2720)**
- **doc: update multi-stage dockerfile to use venv**
- **fix: keep same logic**
- **feat: install python using pbs-installer (#2721)**
- **fix: supports custom distribution files path for pdm publish (#2724)**
- **fix: add socksio dependency**
- **chore: fix news and max_versions.py**
- **chore: Release 2.13.0**
- **chore: update dependencies in pdm.lock**
- **doc: extract lockfile doc from "manage dependencies" doc (#2725)**
- **fix: couldn't find interpreter for global project (#2727)**
- **refactor: sort the pypi.json fixture (#2728)**
- **chore: config codespell with pyproject.toml (#2729)**
- **doc: move doc site to readthedocs (#2736)**
- **doc: change the position of rst badge**
- **doc: fix doc link**
- **doc: fix logo url in readme**
- **fix: add missing right paren in pdm.ps1 Fixes #2734**
- **fix: make the cache package path shorter to solve the windows path problem (#2737)**
- **doc: fix the wording**
- **chore: Release 2.13.1**
- **doc: fix path refs for CHANGELOG.md and CONTRIBUTING.md (#2748)**
- **Doc usage dependency typo (#2741)**
- **fix: ensure poetry authors are parsed properly (fixes #2665) (#2743)**
- **fix: race condition issue for cached package (#2749)**
- **fix: add back `candidate.build()` for backward-compatibility (#2750)**
- **chore: Release 2.13.2**
- **doc: Windows install script update. Fixes #2746**
- **feat: per-source config of ca_certs and client_cert (#2754)**
- **fix(cli): remove all caches like removing individual caches (#2757)**
- **[pre-commit.ci] pre-commit autoupdate (#2756)**
- **fix: use the default http client when downloading python versions Close #2759**
- **fix: test failure**
- **fix: refuse to run recursive composite scripts**
